### PR TITLE
package-type.components: add packageTypeComponents()

### DIFF
--- a/src/components/package-type.components.ts
+++ b/src/components/package-type.components.ts
@@ -1,0 +1,52 @@
+/**
+ * Import will remove at compile time
+ */
+
+import type { ConfigurationInterface } from '@configuration/interfaces/configuration.interface';
+
+/**
+ * Imports
+ */
+
+import { join } from 'path';
+import { mkdirSync, writeFileSync } from 'fs';
+
+/**
+ * Generates a `package.json` file with the appropriate `type` field
+ * based on the format specified in the configuration.
+ *
+ * - If the format is `esm`, the `type` will be set to `"module"`.
+ * - If the format is `cjs`, the `type` will be set to `"commonjs"`.
+ *
+ * The function will ensure that the output directory exists, and if it doesn't,
+ * it will create the necessary directories before writing the `package.json` file.
+ *
+ * @param {ConfigurationInterface} config - The build configuration object containing
+ * esbuild-related settings, such as the output directory (`outdir`) and format (`format`).
+ *
+ * - `config.esbuild.outdir`: The output directory where the `package.json` will be created.
+ * - `config.esbuild.format`: The module format, either `'esm'` or `'cjs'`, that determines the `type` field.
+ *
+ * @throws Will throw an error if there is a problem creating the directory or writing the file.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * const config = {
+ *   esbuild: {
+ *     outdir: 'dist',
+ *     format: 'esm'
+ *   }
+ * };
+ * packageTypeComponents(config);
+ * // This will create 'dist/package.json' with the content: {"type": "module"}
+ * ```
+ */
+
+export function packageTypeComponents(config: ConfigurationInterface): void {
+    const outDir = config.esbuild.outdir ?? '';
+    const type = config.esbuild.format === 'esm' ? 'module' : 'commonjs';
+
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, 'package.json'), `{"type": "${type}"}`);
+}

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -25,6 +25,7 @@ import { analyzeDependencies } from '@services/transpiler.service';
 import { TypeScriptProvider } from '@providers/typescript.provider';
 import { tsConfiguration } from '@providers/configuration.provider';
 import { extractEntryPoints } from '@components/entry-points.component';
+import { packageTypeComponents } from '@components/package-type.components';
 
 /**
  * Manages the build process for a TypeScript project using esbuild.
@@ -367,7 +368,9 @@ export class BuildService {
      */
 
     private async build(): Promise<BuildContext | SameShape<unknown, unknown> | BuildResult> {
+        packageTypeComponents(this.config);
         const esbuild = this.config.esbuild;
+
         if (this.config.hooks) {
             this.pluginsProvider.registerOnEnd(this.config.hooks.onEnd);
             this.pluginsProvider.registerOnLoad(this.config.hooks.onLoad);


### PR DESCRIPTION
Generated `package.json` file will override the main package.json
  in the output directory to ensure support for both ESM and CommonJS formats.