### PR TITLE
cli: add `process.exit` on error

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,4 +26,5 @@ console.log(bannerComponent());
 
 buildWithArgv(process.argv).catch((error: VMRuntimeError & xBuildError) => {
     console.error(error.stack);
+    process.exit(1);
 });


### PR DESCRIPTION
this is to prevent `&&` to be executed
`npm run build && echo 'test'`