### PR TITLE
bash: set `process.exitCode` on errors for consistent error handling

### DIFF
--- a/src/bash.ts
+++ b/src/bash.ts
@@ -480,6 +480,7 @@ async function executeBuild(buildService: BuildService, args: ArgumentsInterface
         }
     } catch (error) {
         logError(error);
+        process.exitCode = 1;
     }
 }
 

--- a/src/components/printer.component.ts
+++ b/src/components/printer.component.ts
@@ -404,6 +404,7 @@ export function appendIssue(buffer: Array<string>, issue: IssueType, symbol: str
 
 export function logBuildIssues(issues: Array<IssueType>, issueType: 'Errors' | 'Warnings'): void {
     if (issues.length === 0) return;
+    if(issueType === 'Errors') process.exitCode = 1;
 
     const isError = issueType === 'Errors';
     const symbol = isError ? ERROR_SYMBOL : WARNING_SYMBOL;
@@ -557,6 +558,7 @@ export function logTypeDiagnostic(name: string, diagnostics: Array<DiagnosticInt
     console.log(`${ status } ${ nameColor }`);
 
     if (hasErrors) {
+        process.exitCode = 1;
         console.log('');
         for (const diagnostic of diagnostics) {
             logTypescriptDiagnostic(diagnostic, errorColor(ERROR_SYMBOL));


### PR DESCRIPTION
## Type of change

- [x] 🐛 Bug fix
- [ ] 💡 New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor / cleanup
- [ ] ⚙️ CI / build tooling

## Changes

* afc2c2cfcfdb02a5b978106bf9ee3be88b0195b9 bash: set `process.exitCode` on errors for consistent error handling