### PR TITLE
Feature/depend

### DIFF
--- a/src/interfaces/configuration.interface.ts
+++ b/src/interfaces/configuration.interface.ts
@@ -658,6 +658,36 @@ export interface VariantBuildInterface extends BaseBuildDefinitionInterface {
         BuildOptions,
         'plugins' | 'define' | 'banner' | 'footer'
     >;
+
+    /**
+     * Variants that must finish building before this variant starts.
+     *
+     * @remarks
+     * Use this field to express build ordering between variants when one output
+     * depends on another being completed first.
+     *
+     * You can provide:
+     * - a single variant name
+     * - an array of variant names
+     *
+     * The build system should resolve these dependencies before running the current
+     * variant and should also detect circular dependencies to avoid infinite loops.
+     *
+     * @example
+     * ```ts
+     * dependOn: 'types'
+     * ```
+     *
+     * @example
+     * ```ts
+     * dependOn: ['types', 'shared']
+     * ```
+     *
+     * @see {@link VariantsType}
+     * @since 2.4.0
+     */
+
+    dependOn?: string | Array<string>;
 }
 
 /**

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -4,12 +4,12 @@
 
 import type { OnLoadResult, Message, PartialMessage } from 'esbuild';
 import type { BuildConfigInterface } from '@interfaces/configuration.interface';
-import type { ReloadOptionsInterface } from '@services/interfaces/build-service.interface';
 import type { BuildContextInterface } from '@providers/interfaces/lifecycle-provider.interface';
 import type { OnEndType, OnStartType } from '@providers/interfaces/lifecycle-provider.interface';
 import type { ResultContextInterface } from '@providers/interfaces/lifecycle-provider.interface';
 import type { BuildResultInterface } from '@providers/interfaces/esbuild-messages-provider.interface';
 import type { DiagnosticInterface } from '@typescript/services/interfaces/typescript-service.interface';
+import type { ReloadOptionsInterface, BuildTreeInterface } from '@services/interfaces/build-service.interface';
 
 /**
  * Imports
@@ -415,27 +415,36 @@ export class BuildService {
     }
 
     /**
-     * Executes the build process for all or specific variants.
+     * Executes the build process for all or specific variants,
+     * respecting `dependOn` ordering and running independent variants in parallel.
      *
      * @param names - Optional array of variant names to build (builds all if omitted)
      *
      * @returns Promise resolving to a map of variant names to their enhanced build results
      *
+     * @throws xBuildError - When a circular dependency is detected before any build starts
      * @throws AggregateError - When any variant build fails, containing all error details
      *
      * @remarks
      * The build process:
-     * 1. Filters variants if specific names are provided
-     * 2. Builds all variants in parallel
-     * 3. Collects results and errors from each variant
-     * 4. Enhances build results with additional metadata
-     * 5. Aggregates errors if any builds failed
-     * 6. Throws AggregateError if errors occurred
+     * 1. Validates the dependency graph — throws immediately on circular deps
+     * 2. Launches all requested variants concurrently
+     * 3. Each variant awaits its `dependOn` dependencies before running
+     * 4. Collects results and errors from each variant without stopping others
+     * 5. Enhances build results with additional metadata
+     * 6. Throws AggregateError if any builds failed
+     *
+     * **Dependency resolution**:
+     * - `dependOn` variants always finish before the dependent variant starts
+     * - A shared dependency (e.g. two variants both depending on `types`) builds
+     *   only once — subsequent dependents await the same running promise
+     * - Independent variants run fully in parallel
      *
      * **Error handling**:
      * - Build failures don't stop other variants from building
-     * - All errors are collected and thrown together after all builds are complete
-     * - Supports both esbuild errors and generic JavaScript errors
+     * - All errors are collected into {@link BuildTreeInterface.errors} and thrown
+     *   together after all builds complete
+     * - Supports both esbuild-specific errors and generic JavaScript errors
      *
      * **Result enhancement**:
      * Build results are processed by {@link enhancedBuildResult} to provide
@@ -459,52 +468,38 @@ export class BuildService {
      * // Only production and staging variants are built
      * ```
      *
-     * @example Handle individual variant errors
+     * @example With dependency ordering
      * ```ts
-     * try {
-     *   await buildService.build();
-     * } catch (error) {
-     *   if (error instanceof AggregateError) {
-     *     console.error(`${error.errors.length} variants failed`);
-     *   }
-     * }
+     * // Given: main dependOn shared, shared dependOn types
+     * // Build order: types → shared → main (dependencies first)
+     * const results = await buildService.build();
      * ```
      *
+     * @see {@link buildVariant} for per-variant execution and caching logic
+     * @see {@link BuildTreeInterface}
      * @see {@link enhancedBuildResult}
      * @see {@link BuildResultInterface}
      * @see {@link VariantService.build}
+     * @see {@link validateDependencies} for circular dependency detection
      *
-     * @since 2.0.0
+     * @since 2.4.0
      */
 
     async build(names?: Array<string>): Promise<Record<string, BuildResultInterface>> {
-        const errorList: Array<Error> = [];
-        const results: Record<string, BuildResultInterface> = {};
-        const buildPromises = Object.entries(this.variants).map(async ([ variantName, variantInstance ]) => {
-            if (names && !names.includes(variantName)) return;
+        const ctx: BuildTreeInterface = {
+            cache: new Map(),
+            errors: [],
+            results: {}
+        };
 
-            try {
-                const result = await variantInstance.build();
-                if (result) results[variantName] = enhancedBuildResult(result);
-            } catch (error) {
-                if (isBuildResultError(error) || error instanceof AggregateError) {
-                    const result = enhancedBuildResult({
-                        errors: error.errors as Array<Message>
-                    });
+        this.validateDependencies(names);
 
-                    errorList.push(...result.errors);
-                } else if (error instanceof Error) {
-                    errorList.push(error);
-                } else {
-                    errorList.push(new Error(String(error)));
-                }
-            }
-        });
+        const targets = names ?? Object.keys(this.variants);
+        await Promise.all(targets.map(name => this.buildVariant(name, ctx)));
 
-        await Promise.allSettled(buildPromises);
-        if (errorList.length) throw new AggregateError(errorList, 'Build failed');
+        if (ctx.errors.length) throw new AggregateError(ctx.errors, 'Build failed');
 
-        return results;
+        return ctx.results;
     }
 
     /**
@@ -656,5 +651,156 @@ export class BuildService {
             this.variants[name] = new VariantService(name, lifecycle, this.config.variants[name], this.argv);
             lifecycle.onLoad(transformerDirective.bind({}, this.variants[name]), 'build-service');
         }
+    }
+
+    /**
+     * Returns the normalized `dependOn` list for a variant.
+     *
+     * @param variantName - The variant to look up
+     *
+     * @returns Array of dependency variant names, empty if none defined
+     *
+     * @remarks
+     * Normalizes the `dependOn` field from the variant configuration into
+     * a consistent array form, since the field accepts either a single
+     * string or an array of strings.
+     *
+     * @see {@link buildVariant}
+     * @see {@link validateDependencies}
+     *
+     * @since 2.4.0
+     */
+
+    private getDependOn(variantName: string): Array<string> {
+        const { dependOn } = this.config.variants?.[variantName] ?? {};
+        if (!dependOn) return [];
+
+        return Array.isArray(dependOn) ? dependOn : [ dependOn ];
+    }
+
+    /**
+     * Validates the dependency graph for all or specific variants before building starts.
+     *
+     * @param names - Optional subset of variant names to validate (validates all if omitted)
+     *
+     * @throws xBuildError - When a circular dependency is detected, with the full cycle
+     * path included in the message (e.g. `Circular dependency detected: main → shared → main`)
+     *
+     * @remarks
+     * Performs a depth-first traversal of the dependency graph using two sets:
+     * - `visited` — variants fully processed, skipped on revisit
+     * - `inStack` — variants in the current traversal path, used to detect cycles
+     *
+     * Dependencies that exist in `dependOn` but have no matching variant instance
+     * in {@link variants} are silently skipped.
+     *
+     * Called by {@link build} before any variant starts, ensuring the entire
+     * graph is valid before any work begins.
+     *
+     * @see {@link build}
+     * @see {@link getDependOn}
+     *
+     * @since 2.4.0
+     */
+
+    private validateDependencies(names?: Array<string>): void {
+        const visited = new Set<string>();
+        const inStack = new Set<string>();
+
+        const visit = (name: string, chain: Array<string>): void => {
+            if (inStack.has(name))
+                throw new xBuildError(`Circular dependency detected: ${ [ ...chain, name ].join(' → ') }`);
+            if (visited.has(name)) return;
+
+            inStack.add(name);
+            for (const dep of this.getDependOn(name)) {
+                if (this.variants[dep]) visit(dep, [ ...chain, name ]);
+            }
+            inStack.delete(name);
+            visited.add(name);
+        };
+
+        for (const name of (names ?? Object.keys(this.variants))) visit(name, []);
+    }
+
+    /**
+     * Executes the build for a single variant after all its dependencies resolve.
+     *
+     * @param name - Variant name to build
+     * @param ctx - Isolated build context for this {@link build} invocation
+     *
+     * @remarks
+     * Called exclusively by {@link buildVariant} after the promise is registered
+     * in {@link BuildTreeInterface.cache}, preventing re-entry.
+     *
+     * Awaits all `dependOn` dependencies concurrently via `Promise.all` before
+     * running the variant. Dependencies missing from {@link variants} are silently skipped.
+     *
+     * Errors are pushed into {@link BuildTreeInterface.errors} rather than thrown,
+     * so all variants attempt to build even if a sibling fails. Handles both
+     * esbuild-specific errors via {@link isBuildResultError} and generic JavaScript errors.
+     *
+     * @see {@link buildVariant}
+     * @see {@link getDependOn}
+     * @see {@link isBuildResultError}
+     * @see {@link BuildTreeInterface}
+     * @see {@link enhancedBuildResult}
+     *
+     * @since 2.4.0
+     */
+
+    private async executeBuild(name: string, ctx: BuildTreeInterface): Promise<void> {
+        const deps = this.getDependOn(name).filter(dep => this.variants[dep]);
+        await Promise.all(deps.map(dep => this.buildVariant(dep, ctx)));
+
+        const instance = this.variants[name];
+        if (!instance) return;
+
+        try {
+            const result = await instance.build();
+            if (result) ctx.results[name] = enhancedBuildResult(result);
+        } catch (error) {
+            if (isBuildResultError(error) || error instanceof AggregateError) {
+                ctx.errors.push(
+                    ...enhancedBuildResult({ errors: error.errors as Array<Message> }).errors
+                );
+            } else {
+                ctx.errors.push(error instanceof Error ? error : new Error(String(error)));
+            }
+        }
+    }
+
+    /**
+     * Builds a single variant, first awaiting any `dependOn` dependencies.
+     *
+     * @param name - Variant name to build
+     * @param ctx - Isolated build context for this {@link build} invocation,
+     * carrying the promise cache, error list, and results map
+     *
+     * @returns Promise that resolves when the variant and all its dependencies finish
+     *
+     * @remarks
+     * Stores its promise in {@link BuildTreeInterface.cache} on first call so any
+     * subsequent caller depending on the same variant awaits the already-running
+     * promise rather than triggering a duplicate build.
+     *
+     * Delegates actual execution to {@link executeBuild} after registering the promise,
+     * ensuring the cache is populated before any async work begins.
+     *
+     * @see {@link build}
+     * @see {@link executeBuild}
+     * @see {@link BuildTreeInterface}
+     *
+     * @since 2.4.0
+     */
+
+    private buildVariant(name: string, ctx: BuildTreeInterface): Promise<void> {
+        const cached = ctx.cache.get(name);
+        if (cached) return cached;
+
+        const promise = this.executeBuild(name, ctx);
+        ctx.cache.set(name, promise);
+
+        return promise;
     }
 }

--- a/src/services/build.service.ts
+++ b/src/services/build.service.ts
@@ -302,7 +302,7 @@ export class BuildService {
      */
 
     reload({ config, clearCache = false }: ReloadOptionsInterface = {}): void {
-        if(clearCache) LanguageHostService.reload();
+        if (clearCache) LanguageHostService.reload();
         if (config) this.configuration.reload(config);
         this.disposeVariants(this.compareKeys(this.config.variants, this.variants));
         this.parseVariants();
@@ -407,7 +407,7 @@ export class BuildService {
     async typeChack(): Promise<Record<string, DiagnosticInterface[]>> {
         const result: Record<string, Array<DiagnosticInterface>> = {};
 
-        for(const variant of Object.values(this.variants)) {
+        for (const variant of Object.values(this.variants)) {
             result[variant.name] = await variant.check();
         }
 
@@ -481,19 +481,19 @@ export class BuildService {
         const errorList: Array<Error> = [];
         const results: Record<string, BuildResultInterface> = {};
         const buildPromises = Object.entries(this.variants).map(async ([ variantName, variantInstance ]) => {
-            if(names && !names.includes(variantName)) return;
+            if (names && !names.includes(variantName)) return;
 
             try {
                 const result = await variantInstance.build();
-                if(result) results[variantName] = enhancedBuildResult(result);
-            } catch(error) {
+                if (result) results[variantName] = enhancedBuildResult(result);
+            } catch (error) {
                 if (isBuildResultError(error) || error instanceof AggregateError) {
                     const result = enhancedBuildResult({
                         errors: error.errors as Array<Message>
                     });
 
                     errorList.push(...result.errors);
-                } else if(error instanceof Error) {
+                } else if (error instanceof Error) {
                     errorList.push(error);
                 } else {
                     errorList.push(new Error(String(error)));
@@ -502,7 +502,7 @@ export class BuildService {
         });
 
         await Promise.allSettled(buildPromises);
-        if(errorList.length) throw new AggregateError(errorList, 'Build failed');
+        if (errorList.length) throw new AggregateError(errorList, 'Build failed');
 
         return results;
     }
@@ -520,7 +520,7 @@ export class BuildService {
      */
 
     private onEndTrigger(context: ResultContextInterface): void {
-        if(this.onEndCallback) this.onEndCallback(context);
+        if (this.onEndCallback) this.onEndCallback(context);
     }
 
     /**
@@ -550,12 +550,12 @@ export class BuildService {
     private async onStartTrigger(context: BuildContextInterface): Promise<OnLoadResult> {
         try {
             const result = await analyzeMacroMetadata(this.variants[context.variantName], context);
-            if(this.onStartCallback) this.onStartCallback(context);
+            if (this.onStartCallback) this.onStartCallback(context);
 
             return result;
-        } catch(error) {
+        } catch (error) {
             const errors: Array<PartialMessage> = [];
-            if(error instanceof AggregateError) {
+            if (error instanceof AggregateError) {
                 for (const err of error.errors) {
                     errors.push({
                         detail: err,
@@ -645,7 +645,7 @@ export class BuildService {
      */
 
     private parseVariants(): void {
-        if(!this.config.variants)
+        if (!this.config.variants)
             throw new xBuildError('Variants are not defined in the configuration');
 
         for (const name of Object.keys(this.config.variants)) {

--- a/src/services/interfaces/build-service.interface.ts
+++ b/src/services/interfaces/build-service.interface.ts
@@ -3,6 +3,7 @@
  */
 
 import type { PartialBuildConfigType } from '@interfaces/configuration.interface';
+import type { BuildResultInterface } from '@providers/interfaces/esbuild-messages-provider.interface';
 
 /**
  * Options used to reload the build service configuration.
@@ -22,6 +23,8 @@ export interface ReloadOptionsInterface {
      * @remarks
      * When provided, the build service reloads using this configuration
      * before recalculating variants.
+     *
+     * @since 2.3.0
      */
 
     config?: PartialBuildConfigType;
@@ -32,7 +35,65 @@ export interface ReloadOptionsInterface {
      * @remarks
      * When enabled, cached file tracking and language service state are reset
      * before the configuration is reloaded.
+     *
+     * @since 2.3.0
      */
 
     clearCache?: boolean;
+}
+
+/**
+ * Isolated state container for a single {@link BuildService.build} invocation.
+ *
+ * @remarks
+ * Created fresh on every `build()` call to ensure concurrent watch-mode
+ * rebuilds cannot share or overwrite each other's state.
+ *
+ * Passed through {@link BuildService.buildVariant} to carry the promise
+ * cache, accumulated errors, and collected results across the full
+ * dependency graph traversal.
+ *
+ * @see {@link BuildService.build}
+ * @see {@link BuildService.buildVariant}
+ *
+ * @since 2.4.0
+ */
+export interface BuildTreeInterface {
+    /**
+     * Promise cache keyed by variant name.
+     *
+     * @remarks
+     * Ensures each variant builds exactly once per `build()` call.
+     * Subsequent callers depending on the same variant await the
+     * already-running promise instead of triggering a duplicate build.
+     *
+     * @since 2.4.0
+     */
+
+    cache: Map<string, Promise<void>>;
+
+    /**
+     * Accumulated build errors across all variants.
+     *
+     * @remarks
+     * Errors are pushed here rather than thrown immediately, so all
+     * variants attempt to build even if a sibling fails. Thrown together
+     * as an `AggregateError` after all builds complete.
+     *
+     * @since 2.4.0
+     */
+
+    errors: Array<Error>;
+
+    /**
+     * Collected build results keyed by variant name.
+     *
+     * @remarks
+     * Populated by {@link BuildService.buildVariant} as each variant
+     * finishes. Only contains results for variants that built successfully.
+     *
+     * @since 2.4.0
+     */
+
+    results: Record<string, BuildResultInterface>;
 }


### PR DESCRIPTION
# Add dependOn build ordering with dependency graph validation

Implements support for the dependOn variant configuration field, enabling variants to declare build-time dependencies on other variants. Introduces dependency graph validation, parallel-aware build execution, and isolated per-call build state safe for watch mode.